### PR TITLE
Implement PBKDF2 key derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Inkrypt is designed to be your **personal journaling sanctuary**—an encrypted,
 
 - **Markdown-based journaling** with live preview
 - **End-to-end local encryption** using AES-256 (Web Crypto API)
+- **Passphrase-based key derivation** via PBKDF2 for AES keys
 - **Local-first file system** with folders and nested structure (IndexedDB or File System Access API)
 - **Custom templates** for recurring entries
 - **Tagging, calendar view, and timeline navigation**

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,0 +1,70 @@
+export async function getEncryptionKey(): Promise<CryptoKey> {
+  const storedSalt = localStorage.getItem('encryptionSalt');
+  const storedHash = localStorage.getItem('passphraseHash');
+  let passphrase: string | null = null;
+  let salt: Uint8Array;
+
+  if (!storedSalt) {
+    passphrase = prompt('Set a passphrase for encryption:') || '';
+    salt = crypto.getRandomValues(new Uint8Array(16));
+    const hashBuffer = await crypto.subtle.digest(
+      'SHA-256',
+      new Uint8Array([...salt, ...new TextEncoder().encode(passphrase)])
+    );
+    localStorage.setItem('encryptionSalt', arrayBufferToBase64(salt.buffer));
+    localStorage.setItem('passphraseHash', arrayBufferToBase64(hashBuffer));
+  } else {
+    salt = base64ToUint8Array(storedSalt);
+    passphrase = prompt('Enter your passphrase:') || '';
+    const hashBuffer = await crypto.subtle.digest(
+      'SHA-256',
+      new Uint8Array([...salt, ...new TextEncoder().encode(passphrase)])
+    );
+    if (storedHash && arrayBufferToBase64(hashBuffer) !== storedHash) {
+      throw new Error('Incorrect passphrase');
+    }
+  }
+
+  return deriveKey(passphrase, salt);
+}
+
+async function deriveKey(passphrase: string, salt: Uint8Array): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const passphraseKey = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: 100000,
+      hash: 'SHA-256'
+    },
+    passphraseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}


### PR DESCRIPTION
## Summary
- introduce new `src/crypto.ts` for deriving AES keys from a passphrase
- update feature list in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd4fd43c83239a1c73b523277542