### PR TITLE
Improve UI/UX for note editing

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -12,6 +12,13 @@ interface State {
     folderId?: number,
     tags?: string[]
   ) => Promise<void>
+  update: (
+    id: number,
+    title: string,
+    content: string,
+    folderId?: number,
+    tags?: string[]
+  ) => Promise<void>
   remove: (id: number) => Promise<void>
 }
 
@@ -47,6 +54,22 @@ export const useNotes = create<State>((set) => ({
         ...state.notes,
         { id, title, content, folderId, tags, createdAt, updatedAt }
       ]
+    }))
+  },
+  async update(id, title, content, folderId = 0, tags: string[] = []) {
+    const encrypted = await encryptText(content)
+    const updatedAt = Date.now()
+    await db.notes.update(id, {
+      title,
+      content: encrypted,
+      folderId,
+      tags,
+      updatedAt
+    })
+    set((state) => ({
+      notes: state.notes.map((n) =>
+        n.id === id ? { ...n, title, content, folderId, tags, updatedAt } : n
+      )
     }))
   },
   async remove(id) {


### PR DESCRIPTION
## Summary
- add ability to update notes
- refine editor with tags, search and new note button
- add simple header and search filter

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6841e1aaa2cc8323ba244a5d1eb8f856